### PR TITLE
Fixed empty videos array in courses.json file

### DIFF
--- a/src/Lib/videos.js
+++ b/src/Lib/videos.js
@@ -49,12 +49,13 @@ export const parseVideoInfo = string => {
 }
 
 export const extractVideosList = async nightmare => {
-    // the last script in the current nightmare page contains all information 
+    // there is a special script in the current nightmare page that contains all information 
     // to put togther a list with the name of video and its url, so extract it
-    const lastScriptContent = await nightmare.evaluate(() => {
+    // As of 08/18/2017 it is the second-last script in the page
+    const videosScriptContent = await nightmare.evaluate(() => {
         const scripts = $('script').toArray()
-        const lastScript = scripts[scripts.length - 1]
-        return lastScript.innerHTML
+        const videosScript = scripts[scripts.length - 2]
+        return videosScript.innerHTML
     })
-    return parseVideoInfo(lastScriptContent)
+    return parseVideoInfo(videosScriptContent)
 }


### PR DESCRIPTION
The HTML DOM of the videos list page has changed and the current `<script>` tag selection is no longer targeting the correct tag. This PR fixes that selection as of today's HTML DOM. (08/18/2017).

This PR solves [this issue (#4)](https://github.com/doshisid/codeschool-download/issues/4)

## How to test 
1.  Clone the repository, checkout my branch, install dependencies, build the package and link it to node's global namespace
```bash
git clone https://github.com/MrNico/codeschool-download.git
cd codeschool-download
git checkout fix/missing-videos
npm install
npm run build
npm link
```
2. In a separate folder where you want your videos to be downloaded, run
```bash
codeschool-download
```
And follow the instructions